### PR TITLE
fix(Makefile): add missing dependency libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ darwin: clean prepare
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks; \
 	chmod +w ./libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/../libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/../libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/../libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/../libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../Frameworks/libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/../Frameworks/libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/../Frameworks/libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/../Frameworks/libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/../Frameworks/libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
 	chmod -w libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
 	cd - >/dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,22 @@ darwin: clean prepare
 	cp /usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
 	cp /usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
 	cp /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
+	cp /usr/local/opt/libpng/lib/libpng16.16.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
+	cp /usr/local/opt/libtiff/lib/libtiff.5.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
+	cp /usr/local/opt/webp/lib/libwebp.7.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
+	cp /usr/local/opt/jpeg/lib/libjpeg.9.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/MacOS; \
 	install_name_tool -change /usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib @executable_path/../Frameworks/libSDL2_image-2.0.0.dylib ${BINARY}-darwin-${GOARCH}; \
 	install_name_tool -change /usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib @executable_path/../Frameworks/libSDL2_ttf-2.0.0.dylib ${BINARY}-darwin-${GOARCH}; \
 	install_name_tool -change /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib ${BINARY}-darwin-${GOARCH}; \
+	sudo install_name_tool -id @executable_path/../Frameworks/libpng16.16.dylib ../Frameworks/libpng16.16.dylib; \
+	sudo install_name_tool -id @executable_path/../Frameworks/libtiff.5.dylib ../Frameworks/libtiff.5.dylib; \
+	sudo install_name_tool -id @executable_path/../Frameworks/libwebp.7.dylib ../Frameworks/libwebp.7.dylib; \
+	sudo install_name_tool -id @executable_path/../Frameworks/libjpeg.9.dylib ../Frameworks/libjpeg.9.dylib; \
+	cd - >/dev/null
+
+	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks; \
 	cd - >/dev/null
 
 	cp -R ./${ASSETS_DIRNAME} ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Resources/${ASSETS_DIRNAME}

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ darwin: clean prepare
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks; \
 	chmod +w ./libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
-	install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/../libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/../libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/../libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/../libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
 	chmod -w libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
 	cd - >/dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,13 @@ darwin: clean prepare
 	cd - >/dev/null
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks; \
-	sudo install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
-	sudo install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
-	sudo install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
-	sudo install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
-	sudo install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
+	chmod +w ./libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
+	chmod -w libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
 	cd - >/dev/null
 
 	cp -R ./${ASSETS_DIRNAME} ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Resources/${ASSETS_DIRNAME}

--- a/Makefile
+++ b/Makefile
@@ -65,18 +65,20 @@ darwin: clean prepare
 	cp /usr/local/opt/libtiff/lib/libtiff.5.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
 	cp /usr/local/opt/webp/lib/libwebp.7.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
 	cp /usr/local/opt/jpeg/lib/libjpeg.9.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
+	cp /usr/local/opt/freetype/lib/libfreetype.6.dylib ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/MacOS; \
 	install_name_tool -change /usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib @executable_path/../Frameworks/libSDL2_image-2.0.0.dylib ${BINARY}-darwin-${GOARCH}; \
 	install_name_tool -change /usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib @executable_path/../Frameworks/libSDL2_ttf-2.0.0.dylib ${BINARY}-darwin-${GOARCH}; \
 	install_name_tool -change /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib ${BINARY}-darwin-${GOARCH}; \
-	sudo install_name_tool -id @executable_path/../Frameworks/libpng16.16.dylib ../Frameworks/libpng16.16.dylib; \
-	sudo install_name_tool -id @executable_path/../Frameworks/libtiff.5.dylib ../Frameworks/libtiff.5.dylib; \
-	sudo install_name_tool -id @executable_path/../Frameworks/libwebp.7.dylib ../Frameworks/libwebp.7.dylib; \
-	sudo install_name_tool -id @executable_path/../Frameworks/libjpeg.9.dylib ../Frameworks/libjpeg.9.dylib; \
 	cd - >/dev/null
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks; \
+	sudo install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
+	sudo install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
+	sudo install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
+	sudo install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
+	sudo install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
 	cd - >/dev/null
 
 	cp -R ./${ASSETS_DIRNAME} ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Resources/${ASSETS_DIRNAME}

--- a/Makefile
+++ b/Makefile
@@ -74,13 +74,17 @@ darwin: clean prepare
 	cd - >/dev/null
 
 	cd ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Frameworks; \
-	chmod +w ./libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
+	chmod +w libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib libfreetype.6.dylib libtiff.5.dylib; \
+	install_name_tool -change /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib libSDL2_image-2.0.0.dylib; \
 	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../Frameworks/libpng16.16.dylib libSDL2_image-2.0.0.dylib; \
 	install_name_tool -change /usr/local/opt/libtiff/lib/libtiff.5.dylib @executable_path/../Frameworks/libtiff.5.dylib libSDL2_image-2.0.0.dylib; \
 	install_name_tool -change /usr/local/opt/webp/lib/libwebp.7.dylib @executable_path/../Frameworks/libwebp.7.dylib libSDL2_image-2.0.0.dylib; \
 	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/../Frameworks/libjpeg.9.dylib libSDL2_image-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib @executable_path/../Frameworks/libSDL2-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
 	install_name_tool -change /usr/local/opt/freetype/lib/libfreetype.6.dylib @executable_path/../Frameworks/libfreetype.6.dylib libSDL2_ttf-2.0.0.dylib; \
-	chmod -w libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib; \
+	install_name_tool -change /usr/local/opt/libpng/lib/libpng16.16.dylib @executable_path/../Frameworks/libpng16.16.dylib libfreetype.6.dylib; \
+	install_name_tool -change /usr/local/opt/jpeg/lib/libjpeg.9.dylib @executable_path/../Frameworks/libjpeg.9.dylib libtiff.5.dylib; \
+	chmod -w libSDL2_image-2.0.0.dylib libSDL2_ttf-2.0.0.dylib libfreetype.6.dylib libtiff.5.dylib; \
 	cd - >/dev/null
 
 	cp -R ./${ASSETS_DIRNAME} ${DIST_DIR}/${BINARY}-darwin-${GOARCH}.app/Contents/Resources/${ASSETS_DIRNAME}

--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,4 @@ darwin-dev:
 
 clean:
 	@echo "[INFO] Cleaning ./dist folder"
-	-rm -rf ${DIST_DIR}/*
+	-rm -rf ${DIST_DIRNAME}/*

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ gopher-ball
 
 I have a JavaScript background (both frontend and NodeJS). I started go a few weeks ago (really enjoy it - just like a NodeJS with pointers and threads 😜).
 
-I needed some project to test on. For the last years, I made a few [video games in JavaScript](http://dev.topheman.com/my-projects/) and I think it's a good way to learn a new programming language (some people will tell that it's a little weird to learn go that way which might be more server/data oriented).
+For my first side project in Go, I decided to make a video game, since I think it's a [very good way](http://dev.topheman.com/my-projects/) to get into a new programming language.
 
-Anyway here is my first golang project. I must thank [Francesc Campoy](https://github.com/campoy) for his great [Youtube Videos JustForFunc](https://youtu.be/aYkxFbd6luY?list=PL64wiCrrxh4Jisi7OcCJIUpguV_f5jGnZ).
+The [Youtube Videos tutorial JustForFunc](https://youtu.be/aYkxFbd6luY?list=PL64wiCrrxh4Jisi7OcCJIUpguV_f5jGnZ) by [Francesc Campoy](https://github.com/campoy) were a great resource.
 
-As you will see, **this is still a work in progress**. If some of you have infos about the build part, please share them via the [issues](https://github.com/topheman/gopher-ball/issues), [twitter](https://twitter.com/topheman) or any other way ...
+At the end, the development only took me a few days whereas the [packaging / build part](#build) took me a lot of time (and is still in progress) ... For this part, I must thank [veeableful](https://github.com/veeableful) for her help [on this issue](https://github.com/veandco/go-sdl2/issues/234).
+
+If you feel like to help, please take a look at the [issues](https://github.com/topheman/gopher-ball/issues).
 
 ## Install
 
@@ -75,22 +77,20 @@ This part is still in progress (for the moment, only MacOS packaging is supporte
 
 There were a lot of apps made in golang with sdl2 (or other golang bridge with c) but none of them implement a **release step** (generate a standalone binary that you could share).
 
-Since, there are C libraries involved, it implies that you link them in some way in the bundle you will generate.
-
-Here is my solution (please share yours):
+Since, there are C libraries involved, it implies that you link them in some way in the bundle you will generate. Here is my solution (please share yours):
 
 #### On MacOS:
 
-I create a bundle with the same folder structure as any MacOS `.app`. Then I copy copy the shared libraries of SDL2 to `Contents/Frameworks` and link them via `install_name_tool`.
+* Create a bundle with the same folder structure as any MacOS `.app`
+* Identify the specific shared libraries (the ones under `/user/local`) using `otool -L <binary_name>` (same as Linux's `ldd`)
+* Repeat previous step on each libraries (to identify the links between nested libraries)
+* Copy those libraries to the bundle inside `Contents/Frameworks`
+* Link the root libraries (the one required by the binary) with `install_name_tool -change <lib_name> @executable_path/../Frameworks/<lib_name> <binary_name>`
+* Link the nested libraries with `install_name_tool -change <lib_name> @executable_path/../Frameworks/<lib_name> <parent_lib_name>`
 
-Some infos:
+**Checkout the [Makefile](https://github.com/topheman/gopher-ball/blob/master/Makefile)** for the whole build steps.
 
-* To list the libs used by your binary: `otool -L <binary_name>` (same as Linux's `ldd`)
-* To link those libraries, use `install_name_tool -change <lib_name> @executable_path/../Frameworks/<lib_name> <binary_name>`
-
-Checkout the [Makefile](https://github.com/topheman/gopher-ball/blob/master/Makefile) for the whole build steps.
-
-Thanks to [veeableful](https://github.com/veeableful) for her help [on this issue](https://github.com/veandco/go-sdl2/issues/234).
+Note: Some part of that could be automated via some recursive script - [here is a start](https://github.com/topheman/gopher-ball/blob/master/bin/otool_list.sh).
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -57,18 +57,22 @@ This part is still in progress (for the moment, only MacOS packaging is supporte
 
 ### Explanation
 
-There were a lot of apps made in golang with sdl2 (or other golang bridge with c) but none of them went all the way through the distribution step (making a standalone binary that you could share). This is the solution I came with (if you have a better one, please share it).
+There were a lot of apps made in golang with sdl2 (or other golang bridge with c) but none of them implement a **release step** (generate a standalone binary that you could share).
 
-In order to make **a binary that you'll be able to share** (with people who don't have go, neither sdl2 installed), you'll have to **link the shared libraries used by the binary** you built (via `go build`) and deliver a binary shipping with those libraries (that you'll have previously pointed to).
+Since, there are C libraries involved, it implies that you link them in some way in the bundle you will generate.
 
-On MacOS:
+Here is my solution (please share yours):
 
-* To list the libs used by your binary: `otool -L <binary_name>`
+#### On MacOS:
+
+I create a bundle with the same folder structure as any MacOS `.app`. Then I copy copy the shared libraries of SDL2 to `Contents/Frameworks` and link them via `install_name_tool`.
+
+Some infos:
+
+* To list the libs used by your binary: `otool -L <binary_name>` (same as Linux's `ldd`)
 * To link those libraries, use `install_name_tool -change <lib_name> @executable_path/../Frameworks/<lib_name> <binary_name>`
 
 Checkout the [Makefile](https://github.com/topheman/gopher-ball/blob/master/Makefile) for the whole build steps.
-
-If you install sdl2 and the go bindings for sdl2, you can build a binary to test the game. However, **it won't be ready for distribution**.
 
 Thanks to [veeableful](https://github.com/veeableful) for her help [on this issue](https://github.com/veandco/go-sdl2/issues/234).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 gopher-ball
 ===========
 
-**DOWNLOAD DEMOS** in the [release section](https://github.com/topheman/gopher-ball/releases) - choose your build by platform - currently only supporting MacOS (darwin).
+<table>
+    <tr>
+        <td>
+            <a href="https://github.com/topheman/gopher-ball/releases" style="text-decoration:none;">
+                <img src="https://raw.githubusercontent.com/topheman/gopher-ball/master/assets/originals/icon.png" width="75" />
+                <strong>DOWNLOAD DEMOS</strong> in the releases section
+            </a>
+            <br />
+            Choose your build by platform - currently only supporting MacOS (darwin).
+        </td>
+        <td style="width:30%; text-align: right;">
+            <a href="http://i.imgur.com/Y1bT6Du.gif">
+                <img src="http://i.imgur.com/G064PZD.gif">
+            </a>
+        </td>
+    </tr>
+</table>
 
 ## Goal
 

--- a/bin/otool_list.sh
+++ b/bin/otool_list.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# from https://gist.github.com/drkibitz/8896013
+
+list=""
+
+otool_list() {
+	local lib="$1"
+	local libs=""
+	if [[ "$list" == "${list/:$lib/}" ]]; then
+		echo "$lib"
+		list="$list:$lib"
+		libs=$(otool -L "$lib" | sed -n 's/^	\(.*\) (compatibility version.*$/\1/p')
+		for lib in $libs
+		do
+			otool_list "$lib"
+		done
+	fi
+}
+
+otool_list "$@"

--- a/build/darwin/dylib.list.txt
+++ b/build/darwin/dylib.list.txt
@@ -1,0 +1,6 @@
+/usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib
+/usr/local/opt/libpng/lib/libpng16.16.dylib
+/usr/local/opt/jpeg/lib/libjpeg.9.dylib
+/usr/local/opt/libtiff/lib/libtiff.5.dylib
+/usr/local/opt/webp/lib/libwebp.7.dylib
+/usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib

--- a/game.go
+++ b/game.go
@@ -127,10 +127,6 @@ func (g *game) handleEvent(event sdl.Event) bool {
 		log.Printf("[Event] %T", event)
 		return true
 	case *sdl.KeyDownEvent:
-		left := event.(*sdl.KeyDownEvent).Keysym.Sym == sdl.K_LEFT
-		right := event.(*sdl.KeyDownEvent).Keysym.Sym == sdl.K_RIGHT
-		up := event.(*sdl.KeyDownEvent).Keysym.Sym == sdl.K_UP
-		down := event.(*sdl.KeyDownEvent).Keysym.Sym == sdl.K_DOWN
 		// sdl.GetKeyboardState() doesn't seem to be working - can't handle two keys at the same time for the moment
 		switch event.(*sdl.KeyDownEvent).Keysym.Sym {
 		case sdl.K_UP:
@@ -142,10 +138,8 @@ func (g *game) handleEvent(event sdl.Event) bool {
 		case sdl.K_RIGHT:
 			g.player.updateDirection(1, 0)
 		}
-		log.Printf("[Event] %T | up: %v | right: %v | down: %v | left: %v", event, up, right, down, left)
 		return false
 	default:
-		log.Printf("[Event] %T", event)
 		return false
 	}
 }


### PR DESCRIPTION
Makefile for the Mac OS X build:

* Create a bundle with the same folder structure as any MacOS `.app`
* Identify the specific shared libraries (the ones under `/user/local`) using `otool -L <binary_name>` (same as Linux's `ldd`)
* Repeat previous step on each libraries (to identify the links between nested libraries)
* Copy those libraries to the bundle inside `Contents/Frameworks`
* Link the root libraries (the one required by the binary) with `install_name_tool -change <lib_name> @executable_path/../Frameworks/<lib_name> <binary_name>`
* Link the nested libraries with `install_name_tool -change <lib_name> @executable_path/../Frameworks/<lib_name> <parent_lib_name>`