### PR TITLE
chore(Makefile): build windows unstable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ prepare:
 linux: clean prepare
 	@echo "Skipping Linux ..."
 
-windows: cleanwindows prepare
+windows: clean prepare
 	go build -ldflags "-H windowsgui" -o ${BINARY}-windows-${GOARCH}.exe .
 
 	mkdir -p ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
@@ -128,10 +128,6 @@ darwin: clean prepare
 
 darwin-dev:
 	go build -o ${BINARY}.app
-
-cleanwindows:
-	@echo "[INFO] Cleaning ./dist folder"
-	-rm -rf ${DIST_DIRNAME}/*
 
 clean:
 	@echo "[INFO] Cleaning ./dist folder"

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,40 @@ prepare:
 linux: clean prepare
 	@echo "Skipping Linux ..."
 
-windows: clean prepare
-	@echo "Skipping Windows ..."
+windows: cleanwindows prepare
+	go build -ldflags "-H windowsgui" -o ${BINARY}-windows-${GOARCH}.exe .
+
+	mkdir -p ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	mv ${BINARY}-windows-${GOARCH}.exe ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+
+	cp C:\msys64\mingw64\bin\SDL2.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\SDL2_ttf.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\SDL2_image.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libpng16-16.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libtiff-5.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libwebp-6.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libjpeg-8.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libfreetype-6.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\liblzma-5.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\zlib1.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\liblzma-5.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libbz2-1.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libharfbuzz-0.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libgcc_s_seh-1.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libglib-2.0-0.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libgraphite2.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libwinpthread-1.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libintl-8.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libpcre-1.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libstdc++-6.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	cp C:\msys64\mingw64\bin\libiconv-2.dll ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+
+	cp -R ./${ASSETS_DIRNAME} ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}
+	rm -rf ${DIST_DIRNAME}/${BINARY}-windows-${GOARCH}/${ASSETS_DIRNAME}/originals
+
+	cd ./${DIST_DIRNAME}; \
+	zip -r ${BINARY}-windows-${GOARCH}.zip ${BINARY}-windows-${GOARCH}; \
+	cd - >/dev/null
 
 darwin: clean prepare
 	go build -o ${BINARY}-darwin-${GOARCH} .
@@ -96,6 +128,10 @@ darwin: clean prepare
 
 darwin-dev:
 	go build -o ${BINARY}.app
+
+cleanwindows:
+	@echo "[INFO] Cleaning ./dist folder"
+	-rm -rf ${DIST_DIRNAME}/*
 
 clean:
 	@echo "[INFO] Cleaning ./dist folder"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ To list the `dll` used by the binary (using cygwin as bash):
 ldd dist/gopher-ball-windows-amd64/gopher-ball-windows-amd64.exe | grep -v Windows
 ```
 
+Or use [dependencywalker](http://www.dependencywalker.com/).
+
 ## Credits
 
 - assets/imgs/wood-background.png - [source](https://fr.vecteezy.com/art-vectoriel/133727-vector-wood-planks-background) - copyright by [carterart](https://fr.vecteezy.com/membres/carterart)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Since, there are C libraries involved, it implies that you link them in some way
 
 Note: Some part of that could be automated via some recursive script - [here is a start](https://github.com/topheman/gopher-ball/blob/master/bin/otool_list.sh).
 
+#### On Windows:
+
+To list the `dll` used by the binary (using cygwin as bash):
+
+```
+ldd dist/gopher-ball-windows-amd64/gopher-ball-windows-amd64.exe | grep -v Windows
+```
+
 ## Credits
 
 - assets/imgs/wood-background.png - [source](https://fr.vecteezy.com/art-vectoriel/133727-vector-wood-planks-background) - copyright by [carterart](https://fr.vecteezy.com/membres/carterart)


### PR DESCRIPTION
Working Makefile for windows

I'm working on it from a Windows VM on a Mac host with the following setup:

* go from the official msi installer on the website
* [msys2](http://www.msys2.org/) to bring pacman (package manager) and some GNU tools
* [cygwin as terminal](https://www.cygwin.com/)
* [git-for-windows](https://git-for-windows.github.io/) to bring git cli
* added the following to env var `Path`: `C:\msys64\mingw64\bin`, `C:\msys64\usr\bin`, `C:\Program Files\Git\cmd`
* created `C:\Users\MyUser\go\src\github.com\topheman` then cloned `gopher-ball` repo into it